### PR TITLE
Adds a workflow to automatically release the handbook

### DIFF
--- a/.github/workflows/md-to-pdf.yaml
+++ b/.github/workflows/md-to-pdf.yaml
@@ -1,22 +1,45 @@
 name: Compile Markdown to PDF
 on: 
-  push  
-  # branches:
-  #   - main
-  workflow_dispatch
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
 
 jobs:
   compile-markdown-to-pdf:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          #!/bin/bash
+          echo "merging markdown files"
+          
+          cd Handbook/          
+          mkdir out/
+          
+          for file in *.md; do
+            cat "${file}" >> out/handbook.md
+            echo "" >> out/handbook.md
+          done
       - uses: baileyjm02/markdown-to-pdf@v1
         with:
-          input_dir: Handbook
+          input_dir: Handbook/out
           output_dir: pdfs
-          images_dir: Handbook/images
+          images_dir: Handbook/img
           build_html: true
       - uses: actions/upload-artifact@v1
         with:
           name: Handbook
-          path: pdfs
+          path: pdfs          
+      - uses: ncipollo/release-action@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          artifacts: pdfs/handbook.pdf
+          body: |
+            The current version of the official Squadspawn Handbook
+          generateReleaseNotes: true
+          artifactErrorsFailBuild: true
+          tag: latest
+          commit: main
+          name: Squadspawn Handbook
+


### PR DESCRIPTION
If something is pushed to the main branch:
* First, merges all *.md files in `Handbook/`.
* Then, compiles the result to a pdf and uploads it as an artifact.
* Finally, creates a GitHub release with the compiled pdf.

The temporary files, i.e., the merged Markdown files and the pdf, are discarded at then end and only available as artifacts of the github action or the release. They do not pollute the repository.